### PR TITLE
Changes definition of thermal_expansion and haline_contraction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SeawaterPolynomials"
 uuid = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
-version = "0.2.3"
+version = "0.3.0"
 
 [compat]
 julia = "^1"

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -1,12 +1,72 @@
 module SeawaterPolynomials
 
 """
-    AbstractSeawaterPolynomial
+    thermal_sensitivity(Θ, Sᴬ, Z, equation_of_state)
 
-Abstract type for Boussinesq equations of state expressed as polynomial functions
-of conservative temperature, absolute salinity, and geopotential depth.
+Returns the "Boussinesq thermal expansion coefficient" defined as,
+
+```math
+α = - ∂ρ / ∂Θ ,
+```
+
+for a seawater parcel with conservative tempertuare `Θ`, absolute salinity `Sᴬ`, at the
+geopotential height `Z`, and using the Boussinesq `equation_of_state`. The thermal expansion
+coefficient measures how much seawater density changes when conservative temperature is changed.
+'Thermal expansion' is so named because, due to sign convention, positive values reflect decreasing
+seawater density with increasing conservative temperature, and thus an 'expansion' of oceanic
+fluid parcels. In many, but not all conditions in Earth's ocean (at temperatures greater than
+4ᵒC in freshwater), the thermal expansion coefficient is positive.
+
+The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*
+downwards to negative values, towards the bottom of the ocean.
 """
-abstract type AbstractSeawaterPolynomial end
+function thermal_sensitivity end
+
+"""
+    haline_sensitivity(Θ, Sᴬ, Z, equation_of_state)
+
+Returns the "Boussinesq haline contraction coefficient" defined as
+
+```math
+β = ∂ρ / ∂Sᴬ ,
+```
+
+for a seawater parcel with absolute salinity `Sᴬ` and at fixed conservative tempertuare `Θ`
+and geopotential height `Z`, using the Boussinesq `equation_of_state`. The haline contraction
+coefficient measures how much seawater density changes when absolute salinity is changed.
+'Haline contraction' is so named because, due to sign convention, positive values reflect increasing
+seawater density with increasing absolute salinity, and thus a slight `contraction' of oceanic
+fluid parcels.
+
+The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*
+downwards to negative values, towards the bottom of the ocean.
+"""
+function haline_sensitivity end
+
+struct BoussinesqEquationOfState{P, FT}
+    seawater_polynomial :: P
+      reference_density :: FT
+
+    function BoussinesqEquationOfState(seawater_polynomial, reference_density)
+        FT = eltype(seawater_polynomial)
+        P = typeof(seawater_polynomial)
+        reference_density = convert(FT, reference_density)
+        return new{P, FT}(seawater_polynomial, reference_density)
+    end
+end
+
+const BEOS = BoussinesqEquationOfState
+
+Base.summary(eos::BoussinesqEquationOfState{P, FT}) where {P, FT} =
+    string("BoussinesqEquationOfState{$FT}")
+
+function Base.show(io::IO, eos::BoussinesqEquationOfState)
+    print(io, summary(eos), ":", '\n')
+    print(io, "    ├── seawater_polynomial: ", summary(eos.seawater_polynomial), '\n')
+    print(io, "    └── reference_density: ", eos.reference_density)
+end
+
+@inline reference_density(eos) = eos.reference_density
 
 """
     ρ(Θ, Sᴬ, Z, equation_of_state)
@@ -34,18 +94,22 @@ The function aliases `density_anomaly`.
 """
 function ρ′ end
 
+const total_density = ρ
+const density_anomaly = ρ′
+
 """
     thermal_expansion(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the thermal expansion coefficient,
+Returns the Boussinesq thermal expansion coefficient,
 
 ```math
-α = - ∂ρ / ∂Θ ,
+α = - ρᵣ⁻¹ ∂ρ / ∂Θ ,
 ```
 
-for a seawater parcel with conservative tempertuare `Θ`, absolute salinity `Sᴬ`, at the
-geopotential height `Z`, and using the Boussinesq `equation_of_state`. The thermal expansion
-coefficient measures how much seawater density changes when conservative temperature is changed.
+for a seawater parcel with reference density `ρᵣ` and conservative temperture `Θ`,
+at fixed absolute salinity `Sᴬ` and geopotential height `Z`,
+using the Boussinesq `equation_of_state`. The thermal expansion coefficient
+describes seawater density changes due to changes in conservative temperature.
 'Thermal expansion' is so named because, due to sign convention, positive values reflect decreasing
 seawater density with increasing conservative temperature, and thus an 'expansion' of oceanic
 fluid parcels. In many, but not all conditions in Earth's ocean (at temperatures greater than
@@ -54,20 +118,21 @@ fluid parcels. In many, but not all conditions in Earth's ocean (at temperatures
 The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*
 downwards to negative values, towards the bottom of the ocean.
 """
-function thermal_expansion end
+@inline thermal_expansion(Θ, Sᴬ, Z, eos::BEOS) = thermal_sensitivity(Θ, Sᴬ, Z, eos) / eos.reference_density
 
 """
     haline_contraction(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the haline contraction coefficient,
+Returns the "Boussinesq haline contraction coefficient" defined as
 
 ```math
-β = ∂ρ / ∂Sᴬ ,
+β = ρᵣ⁻¹ ∂ρ / ∂Sᴬ ,
 ```
 
-for a seawater parcel with absolute salinity `Sᴬ` and at fixed conservative tempertuare `Θ`
-and geopotential height `Z`, using the Boussinesq `equation_of_state`. The haline contraction
-coefficient measures how much seawater density changes when absolute salinity is changed.
+for a seawater parcel with reference density `ρᵣ` and absolute salinity `Sᴬ`, 
+at fixed conservative temperture `Θ` and geopotential height `Z`,
+using the Boussinesq `equation_of_state`. The haline contraction coefficient 
+describes changes in seawater density due to changes in absolute salinity.
 'Haline contraction' is so named because, due to sign convention, positive values reflect increasing
 seawater density with increasing absolute salinity, and thus a slight `contraction' of oceanic
 fluid parcels.
@@ -75,17 +140,15 @@ fluid parcels.
 The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*
 downwards to negative values, towards the bottom of the ocean.
 """
-function haline_contraction end
+@inline haline_contraction(Θ, Sᴬ, Z, eos::BEOS) = haline_sensitivity(Θ, Sᴬ, Z, eos) / eos.reference_density
 
-const total_density = ρ
-const density_anomaly = ρ′
+"""
+    AbstractSeawaterPolynomial
 
-struct BoussinesqEquationOfState{P, FT}
-    seawater_polynomial :: P
-      reference_density :: FT
-end
-
-@inline reference_density(eos) = eos.reference_density
+Abstract type for Boussinesq equations of state expressed as polynomial functions
+of conservative temperature, absolute salinity, and geopotential depth.
+"""
+abstract type AbstractSeawaterPolynomial end
 
 include("SecondOrderSeawaterPolynomials.jl")
 include("TEOS10.jl")

--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -7,7 +7,7 @@ export
 
 using SeawaterPolynomials: AbstractSeawaterPolynomial, BoussinesqEquationOfState
 
-import SeawaterPolynomials: ρ′, thermal_expansion, haline_contraction
+import SeawaterPolynomials: ρ′, thermal_sensitivity, haline_sensitivity
 
 """
     struct SecondOrderSeawaterPolynomial{FT} <: AbstractSeawaterPolynomial
@@ -46,6 +46,21 @@ end
 
 const EOS₂ = BoussinesqEquationOfState{<:SecondOrderSeawaterPolynomial}
 
+Base.eltype(::SecondOrderSeawaterPolynomial{FT}) where FT = FT
+Base.summary(::SecondOrderSeawaterPolynomial{FT}) where FT = "SecondOrderSeawaterPolynomial{$FT}"
+
+signstr(x) = sign(x) < 0 ? " - " : " + "
+
+function Base.show(io::IO, eos::SecondOrderSeawaterPolynomial)
+    print(io, eos.R₁₀₀, " Sᴬ")
+    print(io, signstr(eos.R₀₁₀), abs(eos.R₀₁₀), " Θ")
+    print(io, signstr(eos.R₁₀₁), abs(eos.R₁₀₁), " Θ²")
+    print(io, signstr(eos.R₀₁₁), abs(eos.R₀₁₁), " Θ Z")
+    print(io, signstr(eos.R₁₁₀), abs(eos.R₁₁₀), " Sᴬ²")
+    print(io, signstr(eos.R₀₂₀), abs(eos.R₀₂₀), " Sᴬ Z")
+    print(io, signstr(eos.R₂₀₀), abs(eos.R₂₀₀), " Sᴬ Θ")
+end
+    
 @inline ρ′(Θ, Sᴬ, Z, eos::EOS₂) = (  eos.seawater_polynomial.R₁₀₀ * Sᴬ
                                    + eos.seawater_polynomial.R₀₁₀ * Θ
                                    + eos.seawater_polynomial.R₀₂₀ * Θ^2
@@ -54,12 +69,12 @@ const EOS₂ = BoussinesqEquationOfState{<:SecondOrderSeawaterPolynomial}
                                    - eos.seawater_polynomial.R₁₀₁ * Sᴬ * Z
                                    + eos.seawater_polynomial.R₁₁₀ * Sᴬ * Θ )
 
-@inline thermal_expansion(Θ, Sᴬ, Z, eos::EOS₂) = (      eos.seawater_polynomial.R₀₁₀
-                                                  + 2 * eos.seawater_polynomial.R₀₂₀ * Θ
-                                                  -     eos.seawater_polynomial.R₀₁₁ * Z
-                                                  +     eos.seawater_polynomial.R₁₁₀ * Sᴬ )
+@inline thermal_sensitivity(Θ, Sᴬ, Z, eos::EOS₂) = (      eos.seawater_polynomial.R₀₁₀
+                                                    + 2 * eos.seawater_polynomial.R₀₂₀ * Θ
+                                                    -     eos.seawater_polynomial.R₀₁₁ * Z
+                                                    +     eos.seawater_polynomial.R₁₁₀ * Sᴬ )
 
-@inline haline_contraction(Θ, Sᴬ, Z, eos::EOS₂) = (      eos.seawater_polynomial.R₁₀₀
+@inline haline_sensitivity(Θ, Sᴬ, Z, eos::EOS₂) = (      eos.seawater_polynomial.R₁₀₀
                                                    + 2 * eos.seawater_polynomial.R₂₀₀ * Sᴬ
                                                    -     eos.seawater_polynomial.R₁₀₁ * Z
                                                    +     eos.seawater_polynomial.R₁₁₀ * Θ )
@@ -139,10 +154,8 @@ temperature and salinity distribution.
 For more information, type `help?> RoquetSeawaterPolynomial`.
 """
 LinearRoquetSeawaterPolynomial(FT=Float64) =
-    SecondOrderSeawaterPolynomial{FT}(
-                                      R₀₁₀ = - 1.775e-1,
-                                      R₁₀₀ =   7.718e-1,
-                                     )
+    SecondOrderSeawaterPolynomial{FT}(R₀₁₀ = - 1.775e-1,
+                                      R₁₀₀ =   7.718e-1)
 
 """
     CabbelingRoquetSeawaterPolynomial(FT=Float64)
@@ -153,11 +166,9 @@ optimized for the 'current' oceanic temperature and salinity distribution.
 For more information, type `help?> RoquetSeawaterPolynomial`.
 """
 CabbelingRoquetSeawaterPolynomial(FT=Float64) =
-    SecondOrderSeawaterPolynomial{FT}(
-                                      R₀₁₀ = - 0.844e-1,
+    SecondOrderSeawaterPolynomial{FT}(R₀₁₀ = - 0.844e-1,
                                       R₁₀₀ =   7.718e-1,
-                                      R₀₂₀ = - 4.561e-3,
-                                     )
+                                      R₀₂₀ = - 4.561e-3)
 
 """
     CabbelingThermobaricityRoquetSeawaterPolynomial(FT=Float64)
@@ -169,12 +180,10 @@ distribution.
 For more information, type `help?> RoquetSeawaterPolynomial`.
 """
 CabbelingThermobaricityRoquetSeawaterPolynomial(FT=Float64) =
-    SecondOrderSeawaterPolynomial{FT}(
-                                      R₀₁₀ = - 0.651e-1,
+    SecondOrderSeawaterPolynomial{FT}(R₀₁₀ = - 0.651e-1,
                                       R₁₀₀ =   7.718e-1,
                                       R₀₂₀ = - 5.027e-3,
-                                      R₀₁₁ = - 2.5681e-5,
-                                     )
+                                      R₀₁₁ = - 2.5681e-5)
 
 """
     FreezingRoquetSeawaterPolynomial(FT=Float64)
@@ -186,12 +195,10 @@ distribution.
 For more information, type `help?> RoquetSeawaterPolynomial`.
 """
 FreezingRoquetSeawaterPolynomial(FT=Float64) =
-    SecondOrderSeawaterPolynomial{FT}(
-                                      R₀₁₀ = - 0.491e-1,
+    SecondOrderSeawaterPolynomial{FT}(R₀₁₀ = - 0.491e-1,
                                       R₁₀₀ =   7.718e-1,
                                       R₀₂₀ = - 5.027e-3,
-                                      R₀₁₁ = - 2.5681e-5,
-                                     )
+                                      R₀₁₁ = - 2.5681e-5)
 
 """
     SecondOrderRoquetSeawaterPolynomial(FT=Float64)
@@ -202,14 +209,12 @@ optimized for the 'current' oceanic temperature and salinity  distribution.
 For more information, type `help?> RoquetSeawaterPolynomial`.
 """
 SecondOrderRoquetSeawaterPolynomial(FT=Float64) =
-    SecondOrderSeawaterPolynomial{FT}(
-                                      R₀₁₀ =   0.182e-1,
+    SecondOrderSeawaterPolynomial{FT}(R₀₁₀ =   0.182e-1,
                                       R₁₀₀ =   8.078e-1,
                                       R₀₂₀ = - 4.937e-3,
                                       R₀₁₁ = - 2.4677e-5,
                                       R₂₀₀ = - 1.115e-4,
                                       R₁₀₁ = - 8.241e-6,
-                                      R₁₁₀ = - 2.446e-3
-                                     )
+                                      R₁₁₀ = - 2.446e-3)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,8 +46,8 @@ end
             eos = RoquetEquationOfState(FT)
 
             @test SeawaterPolynomials.ρ′(0, 0, 0, eos) == 0
-            @test SeawaterPolynomials.haline_contraction(0, 0, 0, eos) == eos.seawater_polynomial.R₁₀₀
-            @test SeawaterPolynomials.thermal_expansion(0, 0, 0, eos) == eos.seawater_polynomial.R₀₁₀
+            @test SeawaterPolynomials.haline_sensitivity(0, 0, 0, eos) == eos.seawater_polynomial.R₁₀₀
+            @test SeawaterPolynomials.thermal_sensitivity(0, 0, 0, eos) == eos.seawater_polynomial.R₀₁₀
         end
     end
 
@@ -71,8 +71,8 @@ end
         @test SeawaterPolynomials.TEOS10.r₀(ζ) ≈ 4.59763035
         @test SeawaterPolynomials.TEOS10.r′(τ, s, ζ) ≈ 1022.85377
 
-        @test SeawaterPolynomials.TEOS10.ρ′(Θ, S, Z, eos) ≈ 1027.45140
-        @test SeawaterPolynomials.TEOS10.thermal_expansion(Θ, S, Z, eos) ≈ 0.179646281
-        @test SeawaterPolynomials.TEOS10.haline_contraction(Θ, S, Z, eos) ≈ 0.765555368
+        @test SeawaterPolynomials.TEOS10.ρ(Θ, S, Z, eos) ≈ 1027.45140
+        @test SeawaterPolynomials.TEOS10.thermal_sensitivity(Θ, S, Z, eos) ≈ 0.179646281
+        @test SeawaterPolynomials.TEOS10.haline_sensitivity(Θ, S, Z, eos) ≈ 0.765555368
     end
 end


### PR DESCRIPTION
Also fixes the definition of the density perturbation and total density for TEOS10.

This PR introduces the concepts "thermal sensitivity" and "haline sensitivity". These are the partial derivatives of density with respect to (the negative of) conservative temperature and absolute salinity, respectively.

Then `thermal_expansion` is defined,

```
thermal_expansion = thermal_sensitivity / reference_density
```

same for the haline coefficient. 

Now:

```julia
julia> using SeawaterPolynomials
[ Info: Precompiling SeawaterPolynomials [d496a93d-167e-4197-9f49-d3af4ff8fe40]

julia> eos = SeawaterPolynomials.SecondOrderSeawaterPolynomials.RoquetEquationOfState(:CabbelingThermobaricity)
BoussinesqEquationOfState{Float64}:
    ├── seawater_polynomial: SecondOrderSeawaterPolynomial{Float64}
    └── reference_density: 1024.6

julia> using SeawaterPolynomials: thermal_expansion, haline_contraction

julia> thermal_expansion(0, 0, 0, eos)
-6.353699004489558e-5

julia> haline_contraction(0, 0, 0, eos)
0.0007532695686121414
```

and

```julia
julia> eos = SeawaterPolynomials.TEOS10.TEOS10EquationOfState()
BoussinesqEquationOfState{Float64}:
    ├── seawater_polynomial: TEOS10SeawaterPolynomial{Float64}
    └── reference_density: 1020.0

julia> thermal_expansion(0, 0, 0, eos)
-6.303301081954387e-5

julia> haline_contraction(0, 0, 0, eos)
0.0008000626354612623
```

Also

```julia
julia> SeawaterPolynomials.ρ′(0, 0, 0, eos)
-20.156588082935855
```

Closes #22
Closes #21 