### PR TITLE
Update docstrings for `SeaWaterPolynomials.jl`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ docs/Manifest.toml
 *.DS_Store
 
 .swp
+
+# vscode
+.vscode

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,7 +17,7 @@ makedocs(
      format = format,
     authors = "Gregory L. Wagner and Ali Ramadhan",
    sitename = "SeawaterPolynomials.jl",
-  
+
       pages = Any[
               "Home" => "index.md",
               "API" => "API.md",

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -25,7 +25,7 @@ function thermal_sensitivity end
 """
     haline_sensitivity(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the "Boussinesq haline contraction coefficient" for a seawater parcel with absolute
+Return the "Boussinesq haline contraction coefficient" for a seawater parcel with absolute
 salinity `Sᴬ`, at fixed conservative temperature `Θ`, and geopotential height `Z`, using
 the Boussinesq `equation_of_state`. The haline contraction coefficient is
 

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -103,7 +103,7 @@ const density_anomaly = ρ′
 Return the "Boussinesq thermal expansion coefficient" for a seawater parcel with reference
 density `ρᵣ` and conservative temperture `Θ`, at fixed absolute salinity `Sᴬ` and
 geopotential height `Z`, using the Boussinesq `equation_of_state`. The thermal expansion
-coefficient is defined as
+coefficient is
 
 ```math
 α(Θ, Sᴬ, Z) = - \\left.\\frac{1}{ρᵣ} \\frac{∂ρ}{∂Θ}\\right|_{Sᴬ, Z} ,
@@ -126,7 +126,7 @@ downwards to negative values, towards the bottom of the ocean.
 Return the "Boussinesq haline contraction coefficient" for a seawater parcel with reference
 density `ρᵣ` and absolute salinity `Sᴬ`, at fixed conservative temperture `Θ` and
 geopotential height `Z`, using the Boussinesq `equation_of_state`. The haline contraction
-coefficient is defined as
+coefficient is
 
 ```math
 β(Θ, Sᴬ, Z) = \\left.\\frac{1}{ρᵣ} \\frac{∂ρ}{∂Sᴬ}\\right|_{Θ, Z},

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -4,7 +4,7 @@ module SeawaterPolynomials
     thermal_sensitivity(Θ, Sᴬ, Z, equation_of_state)
 
 Returns the "Boussinesq thermal expansion coefficient" for a seawater parcel with
-conservative tempertuare `Θ`, at fixed absolute salinity `Sᴬ` and geopotential height `Z`
+conservative temperature `Θ`, at fixed absolute salinity `Sᴬ`, and geopotential height `Z`
 using the Boussinesq `equation_of_state`. The thermal expansion coefficient is
 
 ```math

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -5,7 +5,7 @@ module SeawaterPolynomials
 
 Returns the "Boussinesq thermal expansion coefficient" for a seawater parcel with
 conservative tempertuare `Θ`, at fixed absolute salinity `Sᴬ` and geopotential height `Z`
-using the Boussinesq `equation_of_state`. The thermal expansion coefficient is defined as,
+using the Boussinesq `equation_of_state`. The thermal expansion coefficient is
 
 ```math
 α(Θ, Sᴬ, Z) = - \\left.\\frac{∂ρ}{∂Θ}\\right|_{Sᴬ, Z} ,

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -100,7 +100,7 @@ const density_anomaly = ρ′
 """
     thermal_expansion(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the Boussinesq thermal expansion coefficient for a seawater parcel with reference
+Return the Boussinesq thermal expansion coefficient for a seawater parcel with reference
 density `ρᵣ` and conservative temperture `Θ`, at fixed absolute salinity `Sᴬ` and
 geopotential height `Z`, using the Boussinesq `equation_of_state`. The thermal expansion
 coefficient is defined as

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -3,7 +3,7 @@ module SeawaterPolynomials
 """
     thermal_sensitivity(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the "Boussinesq thermal expansion coefficient" for a seawater parcel with
+Return the "Boussinesq thermal expansion coefficient" for a seawater parcel with
 conservative temperature `Θ`, at fixed absolute salinity `Sᴬ`, and geopotential height `Z`
 using the Boussinesq `equation_of_state`. The thermal expansion coefficient is
 

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -123,7 +123,7 @@ downwards to negative values, towards the bottom of the ocean.
 """
     haline_contraction(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the "Boussinesq haline contraction coefficient" for a seawater parcel with reference
+Return the "Boussinesq haline contraction coefficient" for a seawater parcel with reference
 density `ρᵣ` and absolute salinity `Sᴬ`, at fixed conservative temperture `Θ` and
 geopotential height `Z`, using the Boussinesq `equation_of_state`. The haline contraction
 coefficient is defined as

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -100,7 +100,7 @@ const density_anomaly = ρ′
 """
     thermal_expansion(Θ, Sᴬ, Z, equation_of_state)
 
-Return the Boussinesq thermal expansion coefficient for a seawater parcel with reference
+Return the "Boussinesq thermal expansion coefficient" for a seawater parcel with reference
 density `ρᵣ` and conservative temperture `Θ`, at fixed absolute salinity `Sᴬ` and
 geopotential height `Z`, using the Boussinesq `equation_of_state`. The thermal expansion
 coefficient is defined as
@@ -134,7 +134,7 @@ coefficient is defined as
 
 and describes changes in seawater density due to changes in absolute salinity.
 'Haline contraction' is so named because, due to sign convention, positive values reflect increasing
-seawater density with increasing absolute salinity, and thus a slight `contraction' of oceanic
+seawater density with increasing absolute salinity, and thus a slight 'contraction' of oceanic
 fluid parcels.
 
 The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -3,15 +3,15 @@ module SeawaterPolynomials
 """
     thermal_sensitivity(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the "Boussinesq thermal expansion coefficient" defined as,
+Returns the "Boussinesq thermal expansion coefficient" for a seawater parcel with
+conservative tempertuare `Θ`, at fixed absolute salinity `Sᴬ` and geopotential height `Z`
+using the Boussinesq `equation_of_state`. The thermal expansion coefficient is defined as,
 
 ```math
-α = - ∂ρ / ∂Θ ,
+α(Θ, Sᴬ, Z) = - \\left.\\frac{∂ρ}{∂Θ}\\right|_{Sᴬ, Z} ,
 ```
 
-for a seawater parcel with conservative tempertuare `Θ`, absolute salinity `Sᴬ`, at the
-geopotential height `Z`, and using the Boussinesq `equation_of_state`. The thermal expansion
-coefficient measures how much seawater density changes when conservative temperature is changed.
+and measures how much seawater density changes when conservative temperature is changed.
 'Thermal expansion' is so named because, due to sign convention, positive values reflect decreasing
 seawater density with increasing conservative temperature, and thus an 'expansion' of oceanic
 fluid parcels. In many, but not all conditions in Earth's ocean (at temperatures greater than
@@ -25,17 +25,17 @@ function thermal_sensitivity end
 """
     haline_sensitivity(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the "Boussinesq haline contraction coefficient" defined as
+Returns the "Boussinesq haline contraction coefficient" for a seawater parcel with absolute
+salinity `Sᴬ`, at fixed conservative tempertuare `Θ` and geopotential height `Z`, using
+the Boussinesq `equation_of_state`. The haline contraction coefficient is defined as
 
 ```math
-β = ∂ρ / ∂Sᴬ ,
+β(Θ, Sᴬ, Z) = \\left.\\frac{∂ρ}{∂Sᴬ}\\right|_{Θ, Z} ,
 ```
 
-for a seawater parcel with absolute salinity `Sᴬ` and at fixed conservative tempertuare `Θ`
-and geopotential height `Z`, using the Boussinesq `equation_of_state`. The haline contraction
-coefficient measures how much seawater density changes when absolute salinity is changed.
+and measures how much seawater density changes when absolute salinity is changed.
 'Haline contraction' is so named because, due to sign convention, positive values reflect increasing
-seawater density with increasing absolute salinity, and thus a slight `contraction' of oceanic
+seawater density with increasing absolute salinity, and thus a slight 'contraction' of oceanic
 fluid parcels.
 
 The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*
@@ -74,7 +74,7 @@ end
 Returns the total density of a seawater parcel with conservative tempertuare `Θ`, absolute
 salinity `Sᴬ`, at the geopotential height `Z`, using the Boussinesq `equation_of_state`.
 
-The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases* 
+The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*
 downwards to negative values, towards the bottom of the ocean.
 
 This function aliases `total_density`.
@@ -84,10 +84,10 @@ This function aliases `total_density`.
 """
     ρ′(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the total density of a seawater parcel with conservative tempertuare `Θ`, absolute
+Returns the density anomaly of a seawater parcel with conservative tempertuare `Θ`, absolute
 salinity `Sᴬ`, at the geopotential height `Z`, using the Boussinesq `equation_of_state`.
 
-The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases* 
+The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*
 downwards to negative values, towards the bottom of the ocean.
 
 The function aliases `density_anomaly`.
@@ -100,16 +100,16 @@ const density_anomaly = ρ′
 """
     thermal_expansion(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the Boussinesq thermal expansion coefficient,
+Returns the Boussinesq thermal expansion coefficient for a seawater parcel with reference
+density `ρᵣ` and conservative temperture `Θ`, at fixed absolute salinity `Sᴬ` and
+geopotential height `Z`, using the Boussinesq `equation_of_state`. The thermal expansion
+coefficient is defined as
 
 ```math
-α = - ρᵣ⁻¹ ∂ρ / ∂Θ ,
+α(Θ, Sᴬ, Z) = - \\left.\\frac{1}{ρᵣ} \\frac{∂ρ}{∂Θ}\\right|_{Sᴬ, Z} ,
 ```
 
-for a seawater parcel with reference density `ρᵣ` and conservative temperture `Θ`,
-at fixed absolute salinity `Sᴬ` and geopotential height `Z`,
-using the Boussinesq `equation_of_state`. The thermal expansion coefficient
-describes seawater density changes due to changes in conservative temperature.
+and describes seawater density changes due to changes in conservative temperature.
 'Thermal expansion' is so named because, due to sign convention, positive values reflect decreasing
 seawater density with increasing conservative temperature, and thus an 'expansion' of oceanic
 fluid parcels. In many, but not all conditions in Earth's ocean (at temperatures greater than
@@ -123,16 +123,16 @@ downwards to negative values, towards the bottom of the ocean.
 """
     haline_contraction(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the "Boussinesq haline contraction coefficient" defined as
+Returns the "Boussinesq haline contraction coefficient" for a seawater parcel with reference
+density `ρᵣ` and absolute salinity `Sᴬ`, at fixed conservative temperture `Θ` and
+geopotential height `Z`, using the Boussinesq `equation_of_state`. The haline contraction
+coefficient is defined as
 
 ```math
-β = ρᵣ⁻¹ ∂ρ / ∂Sᴬ ,
+β(Θ, Sᴬ, Z) = \\left.\\frac{1}{ρᵣ} \\frac{∂ρ}{∂Sᴬ}\\right|_{Θ, Z},
 ```
 
-for a seawater parcel with reference density `ρᵣ` and absolute salinity `Sᴬ`, 
-at fixed conservative temperture `Θ` and geopotential height `Z`,
-using the Boussinesq `equation_of_state`. The haline contraction coefficient 
-describes changes in seawater density due to changes in absolute salinity.
+and describes changes in seawater density due to changes in absolute salinity.
 'Haline contraction' is so named because, due to sign convention, positive values reflect increasing
 seawater density with increasing absolute salinity, and thus a slight `contraction' of oceanic
 fluid parcels.

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -84,7 +84,7 @@ This function aliases `total_density`.
 """
     ρ′(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the density anomaly of a seawater parcel with conservative tempertuare `Θ`, absolute
+Return the density anomaly of a seawater parcel with conservative temperature `Θ`, absolute
 salinity `Sᴬ`, at the geopotential height `Z`, using the Boussinesq `equation_of_state`.
 
 The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -26,7 +26,7 @@ function thermal_sensitivity end
     haline_sensitivity(Θ, Sᴬ, Z, equation_of_state)
 
 Returns the "Boussinesq haline contraction coefficient" for a seawater parcel with absolute
-salinity `Sᴬ`, at fixed conservative tempertuare `Θ` and geopotential height `Z`, using
+salinity `Sᴬ`, at fixed conservative temperature `Θ`, and geopotential height `Z`, using
 the Boussinesq `equation_of_state`. The haline contraction coefficient is
 
 ```math

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -71,7 +71,7 @@ end
 """
     ρ(Θ, Sᴬ, Z, equation_of_state)
 
-Returns the total density of a seawater parcel with conservative tempertuare `Θ`, absolute
+Return the total density of a seawater parcel with conservative temperature `Θ`, absolute
 salinity `Sᴬ`, at the geopotential height `Z`, using the Boussinesq `equation_of_state`.
 
 The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -27,7 +27,7 @@ function thermal_sensitivity end
 
 Returns the "Boussinesq haline contraction coefficient" for a seawater parcel with absolute
 salinity `Sᴬ`, at fixed conservative tempertuare `Θ` and geopotential height `Z`, using
-the Boussinesq `equation_of_state`. The haline contraction coefficient is defined as
+the Boussinesq `equation_of_state`. The haline contraction coefficient is
 
 ```math
 β(Θ, Sᴬ, Z) = \\left.\\frac{∂ρ}{∂Sᴬ}\\right|_{Θ, Z} ,


### PR DESCRIPTION
## Purpose 
Updates to some docstrings in `SeaWaterPolynomials.jl`

## Content

- Re word thermal expansion and haline contraction coefficients doscstrings
- Update the $\LaTeX$ strings for thermal expansion and haline contraction coefficients to match Roequt et al. (2015) equations (1) and (2) (with geopotential height $Z$ in place of pressure $p$)
- total density -> density anomaly in $\rho'$ docstring

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.

## References
[Roquet et al., "Accurate polynomial expressions for the density and specific volume of seawater using the TEOS-10 standard", Ocean Modelling (2015)](https://doi.org/10.1016/j.ocemod.2015.04.002)