### PR TITLE
Fix `Base.show` so coefficients match variables and add simplest "realisitic" equation of state from Roquet et al. (2015)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SeawaterPolynomials"
 uuid = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.3.1"
+version = "0.3.2"
 
 [compat]
 julia = "^1"

--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -53,14 +53,14 @@ Base.summary(::SecondOrderSeawaterPolynomial{FT}) where FT = "SecondOrderSeawate
 signstr(x) = sign(x) < 0 ? " - " : " + "
 
 function Base.show(io::IO, eos::SecondOrderSeawaterPolynomial)
-    print(io, signstr(eos.R₀₀₀), abs(eos.R₀₀₀), " ")
-    print(io, eos.R₁₀₀, " Sᴬ")
+    print(io, eos.R₀₀₀, "")
+    print(io, signstr(eos.R₁₀₀), abs(eos.R₁₀₀), " Sᴬ")
     print(io, signstr(eos.R₀₁₀), abs(eos.R₀₁₀), " Θ")
-    print(io, signstr(eos.R₁₀₁), abs(eos.R₁₀₁), " Θ²")
+    print(io, signstr(eos.R₀₂₀), abs(eos.R₀₂₀), " Θ²")
     print(io, signstr(eos.R₀₁₁), abs(eos.R₀₁₁), " Θ Z")
-    print(io, signstr(eos.R₁₁₀), abs(eos.R₁₁₀), " Sᴬ²")
-    print(io, signstr(eos.R₀₂₀), abs(eos.R₀₂₀), " Sᴬ Z")
-    print(io, signstr(eos.R₂₀₀), abs(eos.R₂₀₀), " Sᴬ Θ")
+    print(io, signstr(eos.R₂₀₀), abs(eos.R₂₀₀), " Sᴬ²")
+    print(io, signstr(eos.R₁₀₁), abs(eos.R₁₀₁), " Sᴬ Z")
+    print(io, signstr(eos.R₁₁₀), abs(eos.R₁₁₀), " Sᴬ Θ")
 end
 
 @inline ρ′(Θ, Sᴬ, Z, eos::EOS₂) = (  eos.seawater_polynomial.R₀₀₀

--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -230,9 +230,9 @@ For more information see [`RoquetSeawaterPolynomial`](@ref).
 """
 function SimplestRealisticRoquetSeawaterPolynomial(FT=Float64)
 
-    Cb = 0.011   # kgm⁻³K⁻²
-    Tₕ = 2.5e-5  # kgm⁻⁴K⁻ꜝ
-    b₀ = 0.77    # kgm⁻³(gkg⁻ꜝ)⁻ꜝ
+    Cb = 0.011   # kg m⁻³ K⁻²
+    Tₕ = 2.5e-5  # kg m⁻⁴ K⁻¹
+    b₀ = 0.77    # kg m⁻³ (g kg⁻¹)⁻¹
     Θ₀ = -4.5    # °C
 
     return SecondOrderSeawaterPolynomial{FT}(R₀₀₀ = (-Cb * Θ₀ ^ 2) / 2,

--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -35,7 +35,6 @@ seawater_polynomial(Θ, Sᴬ, Z) = ⋯ + R₁₁₀ * Sᴬ * Θ + ⋯
 ```
 """
 @Base.kwdef struct SecondOrderSeawaterPolynomial{FT} <: AbstractSeawaterPolynomial
-    R₀₀₀ :: FT = 0
     R₁₀₀ :: FT = 0
     R₀₁₀ :: FT = 0
     R₁₀₁ :: FT = 0
@@ -54,8 +53,7 @@ signstr(x) = sign(x) < 0 ? " - " : " + "
 
 function Base.show(io::IO, eos::SecondOrderSeawaterPolynomial)
     print(io, "ρ' = ")
-    print(io, eos.R₀₀₀, "")
-    print(io, signstr(eos.R₁₀₀), abs(eos.R₁₀₀), " Sᴬ")
+    print(io, eos.R₁₀₀, " Sᴬ")
     print(io, signstr(eos.R₀₁₀), abs(eos.R₀₁₀), " Θ")
     print(io, signstr(eos.R₀₂₀), abs(eos.R₀₂₀), " Θ²")
     print(io, signstr(eos.R₀₁₁), abs(eos.R₀₁₁), " Θ Z")
@@ -64,8 +62,7 @@ function Base.show(io::IO, eos::SecondOrderSeawaterPolynomial)
     print(io, signstr(eos.R₁₁₀), abs(eos.R₁₁₀), " Sᴬ Θ")
 end
 
-@inline ρ′(Θ, Sᴬ, Z, eos::EOS₂) = (  eos.seawater_polynomial.R₀₀₀
-                                   + eos.seawater_polynomial.R₁₀₀ * Sᴬ
+@inline ρ′(Θ, Sᴬ, Z, eos::EOS₂) = (  eos.seawater_polynomial.R₁₀₀ * Sᴬ
                                    + eos.seawater_polynomial.R₀₁₀ * Θ
                                    + eos.seawater_polynomial.R₀₂₀ * Θ^2
                                    - eos.seawater_polynomial.R₀₁₁ * Θ * Z
@@ -112,7 +109,7 @@ Coefficient sets
 
 - `:SimplestRealistic`: the proposed simplest though "realistic" equation of state for
                         seawater from Rouquet et al. (2015),
-                        ``ρ = ρᵣ - R₀₀₀ + R₁₀₀ Sᴬ  + R₀₁₀ Θ - R₀₂₀ Θ² - R₀₁₁ Θ Z``
+                        ``ρ = ρᵣ + R₁₀₀ Sᴬ  + R₀₁₀ Θ - R₀₂₀ Θ² - R₀₁₁ Θ Z``
 
 The optimized coefficients are reported in Table 3 of Roquet et al., "Defining a Simplified
 yet 'Realistic' Equation of State for Seawater", Journal of Physical Oceanography (2015), and
@@ -120,8 +117,9 @@ further discussed around equations (12)--(15). The optimization minimizes errors
 horizontal density gradient estiamted from climatological temperature and salinity distributions
 between the 5 simplified forms chosen by Roquet et. al and the full-fledged
 [TEOS-10](http://www.teos-10.org) equation of state.
-The `:SimplestRealistic` equation of state is equation (17) with a full
-description of the coefficients immediately under equation (17) in Rouquet et al. (2015).
+The `:SimplestRealistic` equation of state is equation (17) in Rouquet et al. (2015) which
+they propose is the simplest yet "realistic" form for the equation of state for the density
+of seawater.
 """
 RoquetSeawaterPolynomial(FT::DataType, coefficient_set=:SecondOrder) =
     eval(Symbol(coefficient_set, :RoquetSeawaterPolynomial))(FT)
@@ -236,8 +234,7 @@ function SimplestRealisticRoquetSeawaterPolynomial(FT=Float64)
     b₀ = 0.77    # kg m⁻³ (g kg⁻¹)⁻¹
     Θ₀ = -4.5    # °C
 
-    return SecondOrderSeawaterPolynomial{FT}(R₀₀₀ = (-Cb * Θ₀ ^ 2) / 2,
-                                             R₁₀₀ = b₀,
+    return SecondOrderSeawaterPolynomial{FT}(R₁₀₀ = b₀,
                                              R₀₁₀ = Cb * Θ₀,
                                              R₀₂₀ = -Cb / 2,
                                              R₀₁₁ = -Tₕ)

--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -72,14 +72,12 @@ end
                                    - eos.seawater_polynomial.R₁₀₁ * Sᴬ * Z
                                    + eos.seawater_polynomial.R₁₁₀ * Sᴬ * Θ )
 
-@inline thermal_sensitivity(Θ, Sᴬ, Z, eos::EOS₂) = (      eos.seawater_polynomial.R₀₀₀
-                                                    +     eos.seawater_polynomial.R₀₁₀
+@inline thermal_sensitivity(Θ, Sᴬ, Z, eos::EOS₂) = (      eos.seawater_polynomial.R₀₁₀
                                                     + 2 * eos.seawater_polynomial.R₀₂₀ * Θ
                                                     -     eos.seawater_polynomial.R₀₁₁ * Z
                                                     +     eos.seawater_polynomial.R₁₁₀ * Sᴬ )
 
-@inline haline_sensitivity(Θ, Sᴬ, Z, eos::EOS₂) = (      eos.seawater_polynomial.R₀₀₀
-                                                   +     eos.seawater_polynomial.R₁₀₀
+@inline haline_sensitivity(Θ, Sᴬ, Z, eos::EOS₂) = (      eos.seawater_polynomial.R₁₀₀
                                                    + 2 * eos.seawater_polynomial.R₂₀₀ * Sᴬ
                                                    -     eos.seawater_polynomial.R₁₀₁ * Z
                                                    +     eos.seawater_polynomial.R₁₁₀ * Θ )

--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -53,6 +53,7 @@ Base.summary(::SecondOrderSeawaterPolynomial{FT}) where FT = "SecondOrderSeawate
 signstr(x) = sign(x) < 0 ? " - " : " + "
 
 function Base.show(io::IO, eos::SecondOrderSeawaterPolynomial)
+    print(io, "ρ' = ")
     print(io, eos.R₀₀₀, "")
     print(io, signstr(eos.R₁₀₀), abs(eos.R₁₀₀), " Sᴬ")
     print(io, signstr(eos.R₀₁₀), abs(eos.R₀₁₀), " Θ")

--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -220,7 +220,7 @@ SecondOrderRoquetSeawaterPolynomial(FT=Float64) =
                                       R₁₁₀ = - 2.446e-3)
 
 """
-    SimplestRealisticRoquetSeawaterPolynomial(FT=Float64)
+    SimplestRealisticRoquetSeawaterPolynomial([FT=Float64])
 
 Parameters for the simplest yet "realistic" equation of state for seawater
 from Roquet et al. (2015) (see equation (17)), optimized for the 'current' oceanic

--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -218,6 +218,7 @@ SecondOrderRoquetSeawaterPolynomial(FT=Float64) =
                                       R₂₀₀ = - 1.115e-4,
                                       R₁₀₁ = - 8.241e-6,
                                       R₁₁₀ = - 2.446e-3)
+
 """
     SimplestRealisticRoquetSeawaterPolynomial(FT=Float64)
 

--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -145,7 +145,7 @@ RoquetEquationOfState(FT::DataType, coefficient_set=:SecondOrder; reference_dens
     BoussinesqEquationOfState(RoquetSeawaterPolynomial(FT, coefficient_set), reference_density)
 
 RoquetEquationOfState(coefficient_set=:SecondOrder; reference_density=1024.6) =
-    RoquetEquationOfState(Float64, coefficient_set, reference_density)
+    RoquetEquationOfState(Float64, coefficient_set; reference_density)
 
 """
     LinearRoquetSeawaterPolynomial([FT=Float64])

--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -147,7 +147,7 @@ RoquetEquationOfState(FT::DataType, coefficient_set=:SecondOrder; reference_dens
     BoussinesqEquationOfState(RoquetSeawaterPolynomial(FT, coefficient_set), reference_density)
 
 RoquetEquationOfState(coefficient_set=:SecondOrder; reference_density=1024.6) =
-    RoquetEquationOfState(Float64, coefficient_set, reference_density=1024.6)
+    RoquetEquationOfState(Float64, coefficient_set, reference_density)
 
 """
     LinearRoquetSeawaterPolynomial([FT=Float64])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,6 +92,6 @@ end
     R₁₀₁ = 8.241e-6
     R₁₁₀ = 2.446e-3
     test_polynomial_string =
-        "$(eval(R₀₀₀)) + $(eval(R₁₀₀)) Sᴬ + $(eval(R₀₁₀)) Θ - $(eval(R₀₂₀)) Θ² - $(eval(R₀₁₁)) Θ Z - $(eval(R₂₀₀)) Sᴬ² - $(eval(R₁₀₁)) Sᴬ Z - $(eval(R₁₁₀)) Sᴬ Θ"
+        "ρ' = $(eval(R₀₀₀)) + $(eval(R₁₀₀)) Sᴬ + $(eval(R₀₁₀)) Θ - $(eval(R₀₂₀)) Θ² - $(eval(R₀₁₁)) Θ Z - $(eval(R₂₀₀)) Sᴬ² - $(eval(R₁₀₁)) Sᴬ Z - $(eval(R₁₁₀)) Sᴬ Θ"
     @test show_polynomial_string == test_polynomial_string
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,9 +46,11 @@ end
 
             eos = RoquetEquationOfState(FT)
 
-            @test SeawaterPolynomials.ρ′(0, 0, 0, eos) == 0
-            @test SeawaterPolynomials.haline_sensitivity(0, 0, 0, eos) == eos.seawater_polynomial.R₁₀₀
-            @test SeawaterPolynomials.thermal_sensitivity(0, 0, 0, eos) == eos.seawater_polynomial.R₀₁₀
+            @test SeawaterPolynomials.ρ′(0, 0, 0, eos) == eos.seawater_polynomial.R₀₀₀
+            @test SeawaterPolynomials.haline_sensitivity(0, 0, 0, eos) ==
+                    eos.seawater_polynomial.R₀₀₀ + eos.seawater_polynomial.R₁₀₀
+            @test SeawaterPolynomials.thermal_sensitivity(0, 0, 0, eos) ==
+                    eos.seawater_polynomial.R₀₀₀ + eos.seawater_polynomial.R₀₁₀
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,9 +48,9 @@ end
 
             @test SeawaterPolynomials.ρ′(0, 0, 0, eos) == eos.seawater_polynomial.R₀₀₀
             @test SeawaterPolynomials.haline_sensitivity(0, 0, 0, eos) ==
-                    eos.seawater_polynomial.R₀₀₀ + eos.seawater_polynomial.R₁₀₀
+                    eos.seawater_polynomial.R₁₀₀
             @test SeawaterPolynomials.thermal_sensitivity(0, 0, 0, eos) ==
-                    eos.seawater_polynomial.R₀₀₀ + eos.seawater_polynomial.R₀₁₀
+                    eos.seawater_polynomial.R₀₁₀
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -78,4 +78,20 @@ end
         @test SeawaterPolynomials.TEOS10.thermal_sensitivity(Θ, S, Z, eos) ≈ 0.179646281
         @test SeawaterPolynomials.TEOS10.haline_sensitivity(Θ, S, Z, eos) ≈ 0.765555368
     end
+
+end
+
+@testset "show" begin
+    show_polynomial_string = repr(RoquetSeawaterPolynomial(:SecondOrder))
+    R₀₀₀ = 0.0
+    R₀₁₀ = 0.182e-1
+    R₁₀₀ = 8.078e-1
+    R₀₂₀ = 4.937e-3
+    R₀₁₁ = 2.4677e-5
+    R₂₀₀ = 1.115e-4
+    R₁₀₁ = 8.241e-6
+    R₁₁₀ = 2.446e-3
+    test_polynomial_string =
+        "$(eval(R₀₀₀)) + $(eval(R₁₀₀)) Sᴬ + $(eval(R₀₁₀)) Θ - $(eval(R₀₂₀)) Θ² - $(eval(R₀₁₁)) Θ Z - $(eval(R₂₀₀)) Sᴬ² - $(eval(R₁₀₁)) Sᴬ Z - $(eval(R₁₁₀)) Sᴬ Θ"
+    @test show_polynomial_string == test_polynomial_string
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using 
+using
     Test,
     SeawaterPolynomials,
     SeawaterPolynomials.SecondOrderSeawaterPolynomials,
@@ -32,13 +32,14 @@ end
 
 @testset "Second-order seawater polynomials" begin
     for coefficient_set in (
-                            :Linear, 
+                            :Linear,
                             :Cabbeling,
                             :CabbelingThermobaricity,
                             :Freezing,
-                            :SecondOrder
+                            :SecondOrder,
+                            :SimplifiedRealistic
                            )
-    
+
         for FT in (Float64, Float32)
             @test instantiate_roquet_polynomial(FT, coefficient_set)
             @test instantiate_roquet_equation_of_state(FT, coefficient_set)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,7 +46,7 @@ end
 
             eos = RoquetEquationOfState(FT)
 
-            @test SeawaterPolynomials.ρ′(0, 0, 0, eos) == eos.seawater_polynomial.R₀₀₀
+            @test SeawaterPolynomials.ρ′(0, 0, 0, eos) == 0
             @test SeawaterPolynomials.haline_sensitivity(0, 0, 0, eos) ==
                     eos.seawater_polynomial.R₁₀₀
             @test SeawaterPolynomials.thermal_sensitivity(0, 0, 0, eos) ==
@@ -83,7 +83,6 @@ end
 
 @testset "show" begin
     show_polynomial_string = repr(RoquetSeawaterPolynomial(:SecondOrder))
-    R₀₀₀ = 0.0
     R₀₁₀ = 0.182e-1
     R₁₀₀ = 8.078e-1
     R₀₂₀ = 4.937e-3
@@ -92,6 +91,6 @@ end
     R₁₀₁ = 8.241e-6
     R₁₁₀ = 2.446e-3
     test_polynomial_string =
-        "ρ' = $(eval(R₀₀₀)) + $(eval(R₁₀₀)) Sᴬ + $(eval(R₀₁₀)) Θ - $(eval(R₀₂₀)) Θ² - $(eval(R₀₁₁)) Θ Z - $(eval(R₂₀₀)) Sᴬ² - $(eval(R₁₀₁)) Sᴬ Z - $(eval(R₁₁₀)) Sᴬ Θ"
+        "ρ' = $(eval(R₁₀₀)) Sᴬ + $(eval(R₀₁₀)) Θ - $(eval(R₀₂₀)) Θ² - $(eval(R₀₁₁)) Θ Z - $(eval(R₂₀₀)) Sᴬ² - $(eval(R₁₀₁)) Sᴬ Z - $(eval(R₁₁₀)) Sᴬ Θ"
     @test show_polynomial_string == test_polynomial_string
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,7 @@ end
                             :CabbelingThermobaricity,
                             :Freezing,
                             :SecondOrder,
-                            :SimplifiedRealistic
+                            :SimplestRealistic
                            )
 
         for FT in (Float64, Float32)


### PR DESCRIPTION

## Purpose 
Add the `coefficient_set` for the simplest yet "realisitic" equation of state from Roquet et al. (2015) and update `Base.show` for `::SecondOrderSeawaterPolynomial` so that coefficients match variables.
Closes #27 


## Content
The simplest yet "realistic" equation of state for seawater from Roquet et al. (2015) is equation (17). Following (17) the coefficients in the form $R_{\beta\chi\varphi}$ are given. This `coefficient_set` and tests are added to the `coefficient_set`s already in this package from Roquet et al. (2015), providing another equation of state that can be used.

This PR also updates `Base.show` so that the coefficients match the variables.

Apologies if this should have been two PR's, I only discovered #27 at the end of what I had initially set out to do which was add the simplest "realistic" eos from Roquet et al. (2015).

Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

----
- [x] I have read and checked the items on the review checklist.

## References
[Roquet et al., "Defining a Simplified Yet “Realistic” Equation of State for Seawater", Journal of Physical Oceanography (2015)](https://doi.org/10.1175/JPO-D-15-0080.1)

