### PR TITLE
Add TEOS10 heat capacity, plus some comments about TEOS10 implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SeawaterPolynomials"
 uuid = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.3.3"
+version = "0.3.4"
 
 [compat]
 julia = "^1"

--- a/src/TEOS10.jl
+++ b/src/TEOS10.jl
@@ -45,6 +45,7 @@ of state for seawater. See
 TEOS10SeawaterPolynomial(FT=Float64) = TEOS10SeawaterPolynomial{FT}()
 
 const EOS₁₀ = BoussinesqEquationOfState{<:TEOS10SeawaterPolynomial}
+const TEOS10EquationOfState{FT} = BoussinesqEquationOfState{<:TEOS10SeawaterPolynomial, FT} where FT
 
 """
     TEOS10EquationOfState(FT=Float64; reference_density=1020)
@@ -61,8 +62,9 @@ Note that according to Roquet et al. (2015):
 
 > "In a Boussinesq model, the choice of the ``ρ₀`` value is important, yet it varies significantly among OGCMs, as it is a matter of personal preference."
 """
-TEOS10EquationOfState(FT=Float64; reference_density=FT(1020)) =
-    BoussinesqEquationOfState(TEOS10SeawaterPolynomial{FT}(), reference_density)
+TEOS10EquationOfState(FT=Float64; reference_density=1020) =
+    BoussinesqEquationOfState(TEOS10SeawaterPolynomial{FT}(),
+                              convert(FT, reference_density))
 
 #####
 ##### Reference values chosen using TEOS-10 recommendation

--- a/src/TEOS10.jl
+++ b/src/TEOS10.jl
@@ -12,6 +12,12 @@ import SeawaterPolynomials: ρ′, thermal_sensitivity, haline_sensitivity
 ##### The TEOS-10 polynomial approximation implemented in this file has been translated
 ##### into Julia from https://github.com/fabien-roquet/polyTEOS/blob/master/polyTEOS10.py
 #####
+##### Note: this implementation codes the polynomial weights as `const`, thus capturing the
+##### polynomial weights implicitly in function closures. As a result of this design, the
+##### polynomial weights cannot be modified without changing this file. To implement a
+##### polynomial approximation with settable weights, the struct `TEOS10SeawaterPolynomial`
+##### should be modified to carry the weights explicitly.
+#####
 
 """
     struct TEOS10SeawaterPolynomial{FT} <: AbstractSeawaterPolynomial end
@@ -19,6 +25,11 @@ import SeawaterPolynomials: ρ′, thermal_sensitivity, haline_sensitivity
 A 55-term polynomial approximation to the TEOS-10 standard equation of state for seawater.
 """
 struct TEOS10SeawaterPolynomial{FT} <: AbstractSeawaterPolynomial end
+
+# The constant, reference heat capacity that acts as a conversion factor between the TEOS10 
+# conservative temperature and potential enthalpy. See equation 3.3.3 (section 3.3, page 27)
+# in the TEOS10 manual: http://www.teos-10.org/pubs/TEOS-10_Manual.pdf
+const teos10_reference_heat_capacity = 3991.86795711963 # J kg⁻¹ K⁻¹
 
 Base.eltype(::TEOS10SeawaterPolynomial{FT}) where FT = FT
 Base.summary(::TEOS10SeawaterPolynomial{FT}) where FT = "TEOS10SeawaterPolynomial{$FT}"


### PR DESCRIPTION
The TEOS10 reference heat capacity is now accessible via

```julia
SeawaterPolynomials.TEOS10.teos10_reference_heat_capacity
```

Here's a description of the TEOS10 reference heat capacity:

<img width="615" alt="image" src="https://github.com/CliMA/SeawaterPolynomials.jl/assets/15271942/2f29b99d-46d3-40e2-833c-a9b0b81d20e6">

from the [TEOS10 manual](http://www.teos-10.org/pubs/TEOS-10_Manual.pdf) (equation 3.3.3, section 3.3, page 27).