### PR TITLE
Align `show` to start of line for `BoussinesqEquationOfState` + update ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
             version: 1
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v2
         env:
           cache-name: cache-artifacts
         with:

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -11,7 +11,7 @@ using the Boussinesq `equation_of_state`. The thermal sensitivity coefficient is
 a(Θ, Sᴬ, Z) = - \\left.\\frac{∂ρ}{∂Θ}\\right|_{Sᴬ, Z} ,
 ```
 
-and measures how much seawater density changes when conservative temperature is changed. 
+and measures how much seawater density changes when conservative temperature is changed.
 It has units of [kg/m³/(g/kg)], and differs from `thermal_expansion` (``α``) by a factor of the reference density ``ρᵣ``.
 In many, but not all conditions in Earth's ocean (at temperatures greater than
 4ᵒC in freshwater), the thermal sensitivity coefficient is positive.
@@ -60,8 +60,8 @@ Base.summary(eos::BoussinesqEquationOfState{P, FT}) where {P, FT} =
 
 function Base.show(io::IO, eos::BoussinesqEquationOfState)
     print(io, summary(eos), ":", '\n')
-    print(io, "    ├── seawater_polynomial: ", summary(eos.seawater_polynomial), '\n')
-    print(io, "    └── reference_density: ", eos.reference_density)
+    print(io, "├── seawater_polynomial: ", summary(eos.seawater_polynomial), '\n')
+    print(io, "└── reference_density: ", eos.reference_density)
 end
 
 @inline reference_density(eos) = eos.reference_density


### PR DESCRIPTION
This is just a nicety (for me at least), apologies if there was a reason the `show` method is defined as it was!

Currently we have

```julia
julia> using SeawaterPolynomials: TEOS10EquationOfState

julia> TEOS10EquationOfState()
BoussinesqEquationOfState{Float64}:
    ├── seawater_polynomial: TEOS10SeawaterPolynomial{Float64}
    └── reference_density: 1020.0
```

This PR aligns the `show` method to the left so we get

```julia
julia> TEOS10EquationOfState()
BoussinesqEquationOfState{Float64}:
├── seawater_polynomial: TEOS10SeawaterPolynomial{Float64}
└── reference_density: 1020.0
```

If you prefer the original method let me know and I can close this but I think it looks better aligned left, though it is a minor purely cosmetic difference.

When the PR triggered ci I got an error related to the verison of `actions/cache` which I have updated to v4 as per the error message.