### PR TITLE
Ensure Θ and Sᴬ are of the same type as eltype(eos)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10' # automatically expands to the latest stable 1.x release of Julia
+          # - '1' # automatically expands to the latest stable 1.x release of Julia
+          - '1.10'
           - '1.11'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1' # automatically expands to the latest stable 1.x release of Julia
-          - nightly
+          - '1.10' # automatically expands to the latest stable 1.x release of Julia
+          - '1.11'
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SeawaterPolynomials"
 uuid = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
 authors = ["Climate Modeling Alliance and contributors"]
-version = "0.3.9"
+version = "0.3.10"
 
 [compat]
 julia = "^1"

--- a/src/SeawaterPolynomials.jl
+++ b/src/SeawaterPolynomials.jl
@@ -122,7 +122,8 @@ fluid parcels. In many, but not all conditions in Earth's ocean (at temperatures
 The geopotential height is defined such that ``Z(x, y) = 0`` at sea level and *decreases*
 downwards to negative values, towards the bottom of the ocean.
 """
-@inline thermal_expansion(Θ, Sᴬ, Z, eos::BEOS) = thermal_sensitivity(Θ, Sᴬ, Z, eos) / eos.reference_density
+@inline thermal_expansion(Θ, Sᴬ, Z, eos::BEOS{<:Any, FT}) where FT =
+    thermal_sensitivity(FT(Θ), FT(Sᴬ), FT(Z), eos) / eos.reference_density
 
 """
     haline_contraction(Θ, Sᴬ, Z, equation_of_state)


### PR DESCRIPTION
Before this PR:

```Julia
julia> using SeawaterPolynomials

julia> eos = SeawaterPolynomials.TEOS10.TEOS10EquationOfState();

julia> α = SeawaterPolynomials.thermal_expansion(0, 35, 0, eos)
ERROR: InexactError: Int64(40.18861714285714)
Stacktrace:
 [1] Int64(x::Float64)
   @ Base ./float.jl:912
 [2] s
   @ ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/SeawaterPolynomials.jl/src/TEOS10.jl:84 [inlined]
 [3] thermal_sensitivity
   @ ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/SeawaterPolynomials.jl/src/TEOS10.jl:262 [inlined]
 [4] thermal_expansion(Θ::Int64, Sᴬ::Int64, Z::Int64, eos::SeawaterPolynomials.BoussinesqEquationOfState{SeawaterPolynomials.TEOS10.TEOS10SeawaterPolynomial{Float64}, Float64})
   @ SeawaterPolynomials ~/Library/CloudStorage/OneDrive-TheUniversityofMelbourne/Documents/Research/SeawaterPolynomials.jl/src/SeawaterPolynomials.jl:125
 [5] top-level scope
   @ REPL[3]:1

julia> α = SeawaterPolynomials.thermal_expansion(0, Float64(35), 0, eos)
5.28716593778166e-5
```

So the temperature could be an integer and it would be converted. But the salinity couldn't...

After this PR:

```Julia
julia> using SeawaterPolynomials^C

julia> eos = SeawaterPolynomials.TEOS10.TEOS10EquationOfState();

julia> α = SeawaterPolynomials.thermal_expansion(0, 35, 0, eos)
5.28716593778166e-5
```