### PR TITLE
fix: correct sign of EOS₂ `thermal_sensitivity` to -∂ρ/∂Θ

### DIFF
--- a/src/SecondOrderSeawaterPolynomials.jl
+++ b/src/SecondOrderSeawaterPolynomials.jl
@@ -78,10 +78,13 @@ end
                                    - eos.seawater_polynomial.R₁₀₁ * Sᴬ * Z
                                    + eos.seawater_polynomial.R₁₁₀ * Sᴬ * Θ )
 
-@inline thermal_sensitivity(Θ, Sᴬ, Z, eos::EOS₂) = (      eos.seawater_polynomial.R₀₁₀
-                                                    + 2 * eos.seawater_polynomial.R₀₂₀ * Θ
-                                                    -     eos.seawater_polynomial.R₀₁₁ * Z
-                                                    +     eos.seawater_polynomial.R₁₁₀ * Sᴬ )
+# Note the leading minus sign: `thermal_sensitivity` is defined as `-∂ρ/∂Θ` (see the
+# `SeawaterPolynomials.thermal_sensitivity` docstring and the TEOS10 implementation), so that
+# `thermal_expansion = thermal_sensitivity / ρᵣ` is positive for warm water.
+@inline thermal_sensitivity(Θ, Sᴬ, Z, eos::EOS₂) = - (      eos.seawater_polynomial.R₀₁₀
+                                                      + 2 * eos.seawater_polynomial.R₀₂₀ * Θ
+                                                      -     eos.seawater_polynomial.R₀₁₁ * Z
+                                                      +     eos.seawater_polynomial.R₁₁₀ * Sᴬ )
 
 @inline haline_sensitivity(Θ, Sᴬ, Z, eos::EOS₂) = (      eos.seawater_polynomial.R₁₀₀
                                                    + 2 * eos.seawater_polynomial.R₂₀₀ * Sᴬ

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,10 +49,21 @@ end
             @test SeawaterPolynomials.ρ′(0, 0, 0, eos) == 0
             @test SeawaterPolynomials.haline_sensitivity(0, 0, 0, eos) ==
                     eos.seawater_polynomial.R₁₀₀
+            # thermal_sensitivity ≡ -∂ρ/∂Θ, so at the origin it equals -R₀₁₀.
             @test SeawaterPolynomials.thermal_sensitivity(0, 0, 0, eos) ==
-                    eos.seawater_polynomial.R₀₁₀
+                    - eos.seawater_polynomial.R₀₁₀
         end
     end
+
+    # The thermal sensitivity coefficient is -∂ρ/∂Θ (see the `thermal_sensitivity`
+    # docstring and the TEOS10 implementation), so `thermal_expansion` must be positive
+    # for warm water where density decreases with temperature (R₀₁₀ < 0 for `:Linear`).
+    eos = RoquetEquationOfState(:Linear)
+    Θ, Sᴬ, Z = 10.0, 35.0, -100.0
+    @test SeawaterPolynomials.thermal_sensitivity(Θ, Sᴬ, Z, eos) ==
+            - eos.seawater_polynomial.R₀₁₀
+    @test SeawaterPolynomials.thermal_sensitivity(Θ, Sᴬ, Z, eos) > 0
+    @test SeawaterPolynomials.thermal_expansion(Θ, Sᴬ, Z, eos) > 0
 
 end
 


### PR DESCRIPTION
Closes #49.

`SecondOrderSeawaterPolynomial` (`EOS₂`) returned `thermal_sensitivity = +∂ρ/∂Θ`, but the documented contract (`src/SeawaterPolynomials.jl`: `a = -∂ρ/∂Θ`) and the `TEOS10` implementation both use `-∂ρ/∂Θ`. As a result, `thermal_expansion = thermal_sensitivity / ρᵣ` came out **negative** for warm seawater with every Roquet/second-order coefficient set, contradicting the `thermal_expansion` docstring and physics.

For example, with the `:Linear` set (`R₀₁₀ = -1.775e-1`):

```julia
thermal_sensitivity(10.0, 35.0, -100.0, eos)  # was -0.1775 (= +∂ρ/∂Θ); should be +0.1775
thermal_expansion(10.0, 35.0, -100.0, eos)     # was negative; should be positive
```

TEOS10 already returns the correct sign (e.g. `thermal_sensitivity(10, 30, -1000, teos) ≈ +0.18`), so this makes the two EOS self-consistent.

## Change
- Negate the `EOS₂` `thermal_sensitivity` expression (the only sign change — `haline_sensitivity` already matched its contract and is untouched).
- Update the existing test that pinned the old sign (`== R₀₁₀` → `== -R₀₁₀`) and add focused assertions that `thermal_sensitivity`/`thermal_expansion` are positive at a warm point for `:Linear`.

Full test suite passes locally.

## Downstream note for maintainers
This flips the sign of `thermal_sensitivity` for the second-order/Roquet EOS. The only downstream consumer I found computing `α = thermal_sensitivity / ρ₀` (`xkykai/SaltyOceanParameterizations.jl`) expects a positive `α`, so this aligns with that usage rather than breaking it, and Oceananigans.jl does not appear to call `thermal_sensitivity` for these EOS. Flagging in case anyone currently relies on / compensates for the old sign.
